### PR TITLE
Added `isWeakAuthenticatorAllowed` input to the definitions

### DIFF
--- a/android/src/main/java/ee/forgr/biometric/AuthActivity.java
+++ b/android/src/main/java/ee/forgr/biometric/AuthActivity.java
@@ -36,8 +36,14 @@ public class AuthActivity extends AppCompatActivity {
         };
     }
 
+    boolean isWeakAuthenticatorAllowed = getIntent().getBooleanExtra("isWeakAuthenticatorAllowed", false);
+
+    int allowedAuthenticators = BiometricManager.Authenticators.BIOMETRIC_STRONG;
+    if (isWeakAuthenticatorAllowed)
+      allowedAuthenticators = allowedAuthenticators | BiometricManager.Authenticators.BIOMETRIC_WEAK;
+
     BiometricPrompt.PromptInfo.Builder builder = new BiometricPrompt.PromptInfo.Builder()
-      .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
+      .setAllowedAuthenticators(allowedAuthenticators)
       .setTitle(
         getIntent().hasExtra("title")
           ? getIntent().getStringExtra("title")

--- a/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
+++ b/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
@@ -116,8 +116,16 @@ public class NativeBiometric extends Plugin {
       call.getBoolean("useFallback", false)
     );
 
+    boolean isWeakAuthenticatorAllowed = Boolean.TRUE.equals(
+            call.getBoolean("isWeakAuthenticatorAllowed", false)
+    );
+
+    int allowedAuthenticators = BiometricManager.Authenticators.BIOMETRIC_STRONG;
+    if (isWeakAuthenticatorAllowed)
+      allowedAuthenticators = allowedAuthenticators | BiometricManager.Authenticators.BIOMETRIC_WEAK;
+
     BiometricManager biometricManager = BiometricManager.from(getContext());
-    int canAuthenticateResult = biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG);
+    int canAuthenticateResult = biometricManager.canAuthenticate(allowedAuthenticators);
     // Using deviceHasCredentials instead of canAuthenticate(DEVICE_CREDENTIAL)
     // > "Developers that wish to check for the presence of a PIN, pattern, or password on these versions should instead use isDeviceSecure."
     // @see https://developer.android.com/reference/androidx/biometric/BiometricManager#canAuthenticate(int)
@@ -178,6 +186,10 @@ public class NativeBiometric extends Plugin {
     }
 
     intent.putExtra("useFallback", useFallback);
+
+    if (call.hasOption("isWeakAuthenticatorAllowed")) {
+      intent.putExtra("isWeakAuthenticatorAllowed", call.getBoolean("isWeakAuthenticatorAllowed"));
+    }
 
     startActivityForResult(call, intent, "verifyResult");
   }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -25,6 +25,12 @@ export interface IsAvailableOptions {
    * Specifies if should fallback to passcode authentication if biometric authentication is not available.
    */
   useFallback: boolean;
+  /**
+   * Only for Android.
+   * Set true, if the application already has active biometric authentication.
+   * This will allow the weak-authentication to prevent issues after updating application to newer versions.
+   */
+  isWeakAuthenticatorAllowed?: boolean;
 }
 
 export interface AvailableResult {
@@ -55,6 +61,12 @@ export interface BiometricOptions {
    * @default 1
    */
   maxAttempts?: number;
+  /**
+   * Only for Android.
+   * Set true, if the application already has active biometric authentication.
+   * This will allow the weak-authentication to prevent issues after updating application to newer versions.
+   */
+  isWeakAuthenticatorAllowed?: boolean;
 }
 
 export interface GetCredentialOptions {


### PR DESCRIPTION
Added `isWeakAuthenticatorAllowed` input to the definitions to allow weak authentication if required.

Relates to mytonwalletorg/mytonwallet-dev#1669